### PR TITLE
fix: failed to resolve correct path in windows

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,11 +13,11 @@ export default defineConfig({
     alias: [
       {
         find: /^@mini-vue3\/(.*?)$/,
-        replacement: resolvePath('/packages/$1/src')
+        replacement: resolvePath('./packages/$1/src')
       },
       {
         find: 'mini-vue3',
-        replacement: resolvePath('/packages/vue/src')
+        replacement: resolvePath('./packages/vue/src')
       }
     ]
   }


### PR DESCRIPTION
using **/** in windows will cause node to resolve the path to the top directory of current disk, like **D:/**